### PR TITLE
Add `id` field in AppStoreConnectErrorResponse

### DIFF
--- a/maker/appstore.py
+++ b/maker/appstore.py
@@ -61,9 +61,16 @@ class AppStoreConnectErrorResponse:
     code: str
     title: str
     detail: str
+    id_: Optional[str] = field(default=None, metadata={"original": "id"})
     source: Optional[str] = field(default=None)
     meta: Optional[Dict[str, Any]] = field(default=None)
     links: Optional[Dict[str, Any]] = field(default=None)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AppStoreConnectErrorResponse":
+        field_map = {f.metadata.get("original", f.name): f.name for f in cls.__dataclass_fields__.values()}
+        kwargs = {field_map.get(k, k): v for k, v in data.items()}
+        return cls(**kwargs)
 
 
 class AppStoreConnectError(Exception):
@@ -71,7 +78,7 @@ class AppStoreConnectError(Exception):
 
     def __init__(self, err: Dict[str, Any]) -> None:
         errs = err.get("errors", [])
-        self.errors = [AppStoreConnectErrorResponse(**data) for data in errs]
+        self.errors = [AppStoreConnectErrorResponse.from_dict(data) for data in errs]
 
 
 def gen_token(secrets: Secrets) -> str:

--- a/tests/appstore/test_app_store_connect_error.py
+++ b/tests/appstore/test_app_store_connect_error.py
@@ -1,0 +1,60 @@
+from maker.appstore import AppStoreConnectError, AppStoreConnectErrorResponse
+
+
+def test_it_errors_empty():
+    err = {"errors": []}
+    actual = AppStoreConnectError(err=err)
+
+    assert actual.errors == []
+
+
+def test_it_errors_exists():
+    err = {
+        "errors": [
+            {
+                "code": "stub code",
+                "status": "stub status",
+                "id": None,
+                "title": "stub title",
+                "detail": "stub detail",
+            },
+            {
+                "code": "stub code",
+                "status": "stub status",
+                "title": "stub title",
+                "detail": "stub detail",
+            },
+            {
+                "code": "stub code",
+                "status": "stub status",
+                "id": "stub id",
+                "title": "stub title",
+                "detail": "stub detail",
+            },
+        ]
+    }
+    actual = AppStoreConnectError(err=err)
+
+    assert actual.errors == [
+        AppStoreConnectErrorResponse(
+            status="stub status",
+            code="stub code",
+            id_=None,
+            title="stub title",
+            detail="stub detail",
+        ),
+        AppStoreConnectErrorResponse(
+            status="stub status",
+            code="stub code",
+            id_=None,
+            title="stub title",
+            detail="stub detail",
+        ),
+        AppStoreConnectErrorResponse(
+            status="stub status",
+            code="stub code",
+            id_="stub id",
+            title="stub title",
+            detail="stub detail",
+        ),
+    ]


### PR DESCRIPTION
Ref: https://developer.apple.com/documentation/appstoreconnectapi/errorresponse/errors-data.dictionary

- [x] Tests